### PR TITLE
Fix feedback to user for Edit and Note commands

### DIFF
--- a/src/main/java/seedu/letsgethired/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/letsgethired/logic/commands/EditCommand.java
@@ -45,7 +45,7 @@ public class EditCommand extends Command {
             + PREFIX_CYCLE + "Summer 2024"
             + PREFIX_STATUS + "Accepted";
 
-    public static final String MESSAGE_EDIT_INTERN_APPLICATION_SUCCESS = "Edited Intern Application: %1$s";
+    public static final String MESSAGE_EDIT_INTERN_APPLICATION_SUCCESS = "Edited Intern Application";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_INTERN_APPLICATION =
             "This intern application already exists in the intern tracker.";

--- a/src/main/java/seedu/letsgethired/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/letsgethired/logic/commands/NoteCommand.java
@@ -27,8 +27,8 @@ public class NoteCommand extends Command {
             + PREFIX_NOTE + "[NOTE]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_NOTE + "John Street is the leading market maker in the APAC region";
-    public static final String MESSAGE_ADD_NOTE_SUCCESS = "Added note to InternApplication: %1$s";
-    public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Removed note from InternApplication";
+    public static final String MESSAGE_ADD_NOTE_SUCCESS = "Added note to Intern Application";
+    public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Removed note from Intern Application";
     public static final String NO_NOTE_PARAMETER_MESSAGE = "A note field must be provided. "
             + "If you intended to delete a note, you can type i/ instead.";
 
@@ -65,10 +65,10 @@ public class NoteCommand extends Command {
         model.setInternApplication(internApplicationToEdit, editedInternApplication);
         model.updateFilteredInternApplicationList(PREDICATE_SHOW_ALL_APPLICATIONS);
 
-        return new CommandResult(generateSuccessMessage(editedInternApplication));
+        return new CommandResult(generateSuccessMessage(), Messages.formatDisplay(editedInternApplication));
     }
 
-    private String generateSuccessMessage(InternApplication internApplicationToEdit) {
+    private String generateSuccessMessage() {
         String message = !note.value.isEmpty() ? MESSAGE_ADD_NOTE_SUCCESS : MESSAGE_DELETE_NOTE_SUCCESS;
         return message;
     }

--- a/src/test/java/seedu/letsgethired/logic/commands/NoteCommandTest.java
+++ b/src/test/java/seedu/letsgethired/logic/commands/NoteCommandTest.java
@@ -45,12 +45,13 @@ public class NoteCommandTest {
         NoteCommand noteCommand = new NoteCommand(INDEX_FIRST_APPLICATION,
                 new InternApplicationBuilder().build().getNote());
 
-        String expectedMessage = NoteCommand.MESSAGE_ADD_NOTE_SUCCESS;
+        CommandResult expectedResult = new CommandResult(NoteCommand.MESSAGE_ADD_NOTE_SUCCESS,
+                Messages.formatDisplay(editedInternApplication));
 
         Model expectedModel = new ModelManager(new InternTracker(model.getInternTracker()), new UserPrefs());
         expectedModel.setInternApplication(model.getFilteredInternApplicationList().get(0), editedInternApplication);
 
-        assertCommandSuccess(noteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(noteCommand, model, expectedResult, expectedModel);
     }
 
     @Test
@@ -61,12 +62,13 @@ public class NoteCommandTest {
                 .withNote("").build();
         NoteCommand noteCommand = new NoteCommand(INDEX_FIRST_APPLICATION, emptyNote);
 
-        String expectedMessage = NoteCommand.MESSAGE_DELETE_NOTE_SUCCESS;
+        CommandResult expectedResult = new CommandResult(NoteCommand.MESSAGE_DELETE_NOTE_SUCCESS,
+                Messages.formatDisplay(editedInternApplication));
 
         Model expectedModel = new ModelManager(new InternTracker(model.getInternTracker()), new UserPrefs());
         expectedModel.setInternApplication(model.getFilteredInternApplicationList().get(0), editedInternApplication);
 
-        assertCommandSuccess(noteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(noteCommand, model, expectedResult, expectedModel);
     }
 
     @Test


### PR DESCRIPTION
Changed the user feedback to not display the internship application in user feedback. Rather, the whole application is displayed on the right pane.

Updated the test cases for NoteCommandTest for the above behaviour