### PR TITLE
Fix find command and edit command

### DIFF
--- a/src/main/java/seedu/letsgethired/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/letsgethired/logic/commands/EditCommand.java
@@ -6,7 +6,6 @@ import static seedu.letsgethired.logic.parser.CliSyntax.PREFIX_CYCLE;
 import static seedu.letsgethired.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.letsgethired.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.letsgethired.logic.parser.CliSyntax.PREFIX_STATUS;
-import static seedu.letsgethired.model.Model.PREDICATE_SHOW_ALL_APPLICATIONS;
 
 import java.util.List;
 import java.util.Objects;
@@ -87,7 +86,6 @@ public class EditCommand extends Command {
         }
 
         model.setInternApplication(internApplicationToEdit, editedInternApplication);
-        model.updateFilteredInternApplicationList(PREDICATE_SHOW_ALL_APPLICATIONS);
         return new CommandResult(MESSAGE_EDIT_INTERN_APPLICATION_SUCCESS,
                 Messages.formatDisplay(editedInternApplication));
     }

--- a/src/main/java/seedu/letsgethired/model/ModelManager.java
+++ b/src/main/java/seedu/letsgethired/model/ModelManager.java
@@ -172,7 +172,7 @@ public class ModelManager implements Model {
     @Override
     public boolean undoAction() {
         boolean isRestored = internTracker.undo();
-        filteredInternApplications = new FilteredList<>(this.internTracker.getApplicationList());
+        filteredInternApplications.setPredicate(PREDICATE_SHOW_ALL_APPLICATIONS);
         return isRestored;
     }
 

--- a/src/test/java/seedu/letsgethired/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/letsgethired/logic/commands/EditCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.letsgethired.logic.commands.CommandTestUtil.VALID_ROLE_BACK_
 import static seedu.letsgethired.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.showInternApplicationAtIndex;
+import static seedu.letsgethired.model.Model.PREDICATE_SHOW_ALL_APPLICATIONS;
 import static seedu.letsgethired.testutil.TypicalIndexes.INDEX_FIRST_APPLICATION;
 import static seedu.letsgethired.testutil.TypicalIndexes.INDEX_SECOND_APPLICATION;
 import static seedu.letsgethired.testutil.TypicalInternApplications.getTypicalInternTracker;
@@ -94,6 +95,8 @@ public class EditCommandTest {
     public void execute_filteredList_success() {
         showInternApplicationAtIndex(model, INDEX_FIRST_APPLICATION);
 
+        model.updateFilteredInternApplicationList(PREDICATE_SHOW_ALL_APPLICATIONS);
+
         InternApplication internApplicationInFilteredList = model.getFilteredInternApplicationList()
                 .get(INDEX_FIRST_APPLICATION.getZeroBased());
         InternApplication editedInternApplication = new InternApplicationBuilder(internApplicationInFilteredList)
@@ -106,6 +109,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new InternTracker(model.getInternTracker()), new UserPrefs());
         expectedModel.setInternApplication(model.getFilteredInternApplicationList().get(0), editedInternApplication);
+        expectedModel.updateFilteredInternApplicationList(PREDICATE_SHOW_ALL_APPLICATIONS);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedDetails, expectedModel);
     }


### PR DESCRIPTION
Fixes #102

1. After finding and editing the list view now stays at filtered applications

2. Find now works even after undoing an operation