### PR TITLE
Fix bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -361,6 +361,8 @@ the [_Command Summary_ section of the **User Guide**](#command-summary) below.
 
 **Notes about the command format:**<br>
 
+* All commands are case-insensitive. So - SORT, sort or SoRt - have no difference whatsoever in behaviour.<br>
+
 * Words in `UPPER_CASE` are **parameters** which you will type in.<br>
     ```
     add n/COMPANY_NAME r/ROLE c/CYCLE

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -361,7 +361,9 @@ the [_Command Summary_ section of the **User Guide**](#command-summary) below.
 
 **Notes about the command format:**<br>
 
-* All commands are case-insensitive. So - SORT, sort or SoRt - have no difference whatsoever in behaviour.<br>
+* All commands are case-sensitive. For example sort is a valid command, but SORT or SoRt are invalid commands.<br>
+
+* All prefixes are case-sensitive. For example s/ (the prefix for status) and S/ (no attached meaning) are considered different
 
 * Words in `UPPER_CASE` are **parameters** which you will type in.<br>
     ```

--- a/src/main/java/seedu/letsgethired/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/letsgethired/logic/parser/AddCommandParser.java
@@ -36,8 +36,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                         PREFIX_ROLE,
                         PREFIX_CYCLE,
                         PREFIX_STATUS,
-                        PREFIX_DEADLINE,
-                        PREFIX_NOTE_INSERT);
+                        PREFIX_DEADLINE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_COMPANY, PREFIX_ROLE, PREFIX_CYCLE)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -49,8 +48,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 PREFIX_ROLE,
                 PREFIX_CYCLE,
                 PREFIX_STATUS,
-                PREFIX_DEADLINE,
-                PREFIX_NOTE_INSERT);
+                PREFIX_DEADLINE);
 
         Company company = ParserUtil.parseCompany(argMultimap.getValue(PREFIX_COMPANY).get());
         Role role = ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get());

--- a/src/main/java/seedu/letsgethired/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/letsgethired/logic/parser/AddCommandParser.java
@@ -4,7 +4,6 @@ import static seedu.letsgethired.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.letsgethired.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.letsgethired.logic.parser.CliSyntax.PREFIX_CYCLE;
 import static seedu.letsgethired.logic.parser.CliSyntax.PREFIX_DEADLINE;
-import static seedu.letsgethired.logic.parser.CliSyntax.PREFIX_NOTE_INSERT;
 import static seedu.letsgethired.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.letsgethired.logic.parser.CliSyntax.PREFIX_STATUS;
 

--- a/src/main/java/seedu/letsgethired/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/letsgethired/logic/parser/FindCommandParser.java
@@ -36,8 +36,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
                 PREFIX_COMPANY, PREFIX_ROLE, PREFIX_CYCLE, PREFIX_STATUS, PREFIX_NOTE_INSERT, PREFIX_DEADLINE);
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_COMPANY,
-                PREFIX_ROLE, PREFIX_CYCLE, PREFIX_STATUS, PREFIX_NOTE_INSERT, PREFIX_DEADLINE);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_COMPANY, PREFIX_ROLE, PREFIX_CYCLE, PREFIX_STATUS, PREFIX_NOTE_INSERT, PREFIX_DEADLINE);
 
         ArrayList<Pair<Prefix, String>> fieldKeywords = new ArrayList<>();
 

--- a/src/main/java/seedu/letsgethired/logic/parser/InternTrackerParser.java
+++ b/src/main/java/seedu/letsgethired/logic/parser/InternTrackerParser.java
@@ -56,7 +56,7 @@ public class InternTrackerParser {
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
-        switch (commandWord.toLowerCase()) {
+        switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);

--- a/src/main/java/seedu/letsgethired/logic/parser/InternTrackerParser.java
+++ b/src/main/java/seedu/letsgethired/logic/parser/InternTrackerParser.java
@@ -56,7 +56,7 @@ public class InternTrackerParser {
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
-        switch (commandWord) {
+        switch (commandWord.toLowerCase()) {
 
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);

--- a/src/main/java/seedu/letsgethired/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/letsgethired/logic/parser/SortCommandParser.java
@@ -24,12 +24,11 @@ public class SortCommandParser implements Parser<SortCommand> {
      */
     public SortCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_COMPANY, PREFIX_ROLE, PREFIX_CYCLE, PREFIX_STATUS,
-                        PREFIX_DEADLINE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_COMPANY, PREFIX_ROLE, PREFIX_CYCLE, PREFIX_STATUS, PREFIX_DEADLINE);
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_COMPANY, PREFIX_ROLE, PREFIX_CYCLE, PREFIX_STATUS,
-                PREFIX_DEADLINE);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_COMPANY, PREFIX_ROLE, PREFIX_CYCLE, PREFIX_STATUS, PREFIX_DEADLINE);
 
         InternApplicationComparator comparator = null;
 

--- a/src/main/java/seedu/letsgethired/model/application/Company.java
+++ b/src/main/java/seedu/letsgethired/model/application/Company.java
@@ -10,13 +10,13 @@ import static seedu.letsgethired.commons.util.AppUtil.checkArgument;
 public class Company implements Comparable<Company> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Company should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Company should not contain a forward slash '/', and it should not be blank";
 
     /*
      * The first character of the status must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "(?!.*\\/)[\\S}][\\p{Print} ]*";
 
     public final String value;
 

--- a/src/main/java/seedu/letsgethired/model/application/Company.java
+++ b/src/main/java/seedu/letsgethired/model/application/Company.java
@@ -56,7 +56,7 @@ public class Company implements Comparable<Company> {
         }
 
         Company otherCompany = (Company) other;
-        return value.equals(otherCompany.value);
+        return value.equalsIgnoreCase(otherCompany.value);
     }
 
     @Override

--- a/src/main/java/seedu/letsgethired/model/application/Cycle.java
+++ b/src/main/java/seedu/letsgethired/model/application/Cycle.java
@@ -55,7 +55,7 @@ public class Cycle implements Comparable<Cycle> {
         }
 
         Cycle otherCycle = (Cycle) other;
-        return value.equals(otherCycle.value);
+        return value.equalsIgnoreCase(otherCycle.value);
     }
 
     @Override

--- a/src/main/java/seedu/letsgethired/model/application/Role.java
+++ b/src/main/java/seedu/letsgethired/model/application/Role.java
@@ -52,7 +52,7 @@ public class Role implements Comparable<Role> {
         }
 
         Role otherRole = (Role) other;
-        return value.equals(otherRole.value);
+        return value.equalsIgnoreCase(otherRole.value);
     }
 
     @Override

--- a/src/test/data/JsonInternTrackerStorageTest/invalidInternApplicationInternTracker.json
+++ b/src/test/data/JsonInternTrackerStorageTest/invalidInternApplicationInternTracker.json
@@ -1,6 +1,6 @@
 {
   "applications": [ {
-    "company": "Internship Application with invalid company field: J@ne Street",
+    "company": "Internship Application with invalid company field: Jane/Street",
     "role" : "Economist",
     "cycle" : "Summer 2022",
     "status" : "Interview",

--- a/src/test/java/seedu/letsgethired/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/letsgethired/logic/LogicManagerTest.java
@@ -5,7 +5,6 @@ import static seedu.letsgethired.logic.Messages.MESSAGE_INVALID_INTERN_APPLICATI
 import static seedu.letsgethired.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.COMPANY_DESC_JANE_STREET;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.CYCLE_DESC_SUMMER;
-import static seedu.letsgethired.logic.commands.CommandTestUtil.NOTE_DESC_BYTEDANCE;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.ROLE_DESC_FULL_STACK;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.STATUS_DESC_ACCEPTED;
 import static seedu.letsgethired.testutil.Assert.assertThrows;
@@ -174,7 +173,6 @@ public class LogicManagerTest {
                 + COMPANY_DESC_JANE_STREET
                 + ROLE_DESC_FULL_STACK
                 + CYCLE_DESC_SUMMER
-                + NOTE_DESC_BYTEDANCE
                 + STATUS_DESC_ACCEPTED;
         InternApplication expectedInternApplication = new InternApplicationBuilder(A).build();
         ModelManager expectedModel = new ModelManager();

--- a/src/test/java/seedu/letsgethired/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/letsgethired/logic/commands/CommandTestUtil.java
@@ -58,7 +58,7 @@ public class CommandTestUtil {
     public static final String DEADLINE_SORT_ORDER_DESCENDING = " " + PREFIX_DEADLINE + VALID_SORT_ORDER_DESCENDING;
 
     public static final String INVALID_COMPANY_DESC =
-            " " + PREFIX_COMPANY + "Jane Street&"; // '&' not allowed in company names
+            " " + PREFIX_COMPANY + "Jane Street/"; // '/' not allowed in company names
     public static final String INVALID_ROLE_DESC = " " + PREFIX_ROLE + " "; // empty string is not allowed in roles
     public static final String INVALID_CYCLE_DESC = " " + PREFIX_CYCLE + "Summer!2023"; // '!' not allowed in cycles
     public static final String INVALID_STATUS_DESC = " " + PREFIX_STATUS; // empty string not allowed in status

--- a/src/test/java/seedu/letsgethired/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/letsgethired/logic/parser/AddCommandParserTest.java
@@ -9,8 +9,6 @@ import static seedu.letsgethired.logic.commands.CommandTestUtil.INVALID_COMPANY_
 import static seedu.letsgethired.logic.commands.CommandTestUtil.INVALID_CYCLE_DESC;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.INVALID_ROLE_DESC;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.INVALID_STATUS_DESC;
-import static seedu.letsgethired.logic.commands.CommandTestUtil.NOTE_DESC_BYTEDANCE;
-import static seedu.letsgethired.logic.commands.CommandTestUtil.NOTE_DESC_JANE_STREET;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.letsgethired.logic.commands.CommandTestUtil.ROLE_DESC_BACK_END;
@@ -47,7 +45,6 @@ public class AddCommandParserTest {
                         + COMPANY_DESC_BYTEDANCE
                         + ROLE_DESC_BACK_END
                         + CYCLE_DESC_WINTER
-                        + NOTE_DESC_BYTEDANCE
                         + STATUS_DESC_REJECTED,
                 new AddCommand(expectedInternApplication));
     }
@@ -57,7 +54,6 @@ public class AddCommandParserTest {
         InternApplication expectedInternApplication = new InternApplicationBuilder(A).build();
         assertParseSuccess(parser, COMPANY_DESC_JANE_STREET
                         + ROLE_DESC_FULL_STACK + CYCLE_DESC_SUMMER
-                        + NOTE_DESC_JANE_STREET
                         + STATUS_DESC_ACCEPTED,
                 new AddCommand(expectedInternApplication));
     }
@@ -97,7 +93,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, INVALID_COMPANY_DESC
                         + ROLE_DESC_BACK_END
                         + CYCLE_DESC_WINTER
-                        + NOTE_DESC_BYTEDANCE
                         + STATUS_DESC_REJECTED,
                 Company.MESSAGE_CONSTRAINTS);
 
@@ -105,7 +100,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, COMPANY_DESC_BYTEDANCE
                         + INVALID_ROLE_DESC
                         + CYCLE_DESC_WINTER
-                        + NOTE_DESC_BYTEDANCE
                         + STATUS_DESC_REJECTED,
                 Role.MESSAGE_CONSTRAINTS);
 
@@ -113,7 +107,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, COMPANY_DESC_BYTEDANCE
                         + ROLE_DESC_BACK_END
                         + INVALID_CYCLE_DESC
-                        + NOTE_DESC_BYTEDANCE
                         + STATUS_DESC_REJECTED,
                 Cycle.MESSAGE_CONSTRAINTS);
 
@@ -121,7 +114,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, COMPANY_DESC_BYTEDANCE
                         + ROLE_DESC_BACK_END
                         + CYCLE_DESC_WINTER
-                        + NOTE_DESC_BYTEDANCE
                         + INVALID_STATUS_DESC,
                 Status.MESSAGE_CONSTRAINTS);
 
@@ -129,7 +121,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, INVALID_COMPANY_DESC
                         + ROLE_DESC_BACK_END
                         + CYCLE_DESC_WINTER
-                        + NOTE_DESC_BYTEDANCE
                         + INVALID_STATUS_DESC,
                 Company.MESSAGE_CONSTRAINTS);
 
@@ -138,7 +129,6 @@ public class AddCommandParserTest {
                         + COMPANY_DESC_BYTEDANCE
                         + ROLE_DESC_BACK_END
                         + CYCLE_DESC_WINTER
-                        + NOTE_DESC_BYTEDANCE
                         + STATUS_DESC_REJECTED,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }

--- a/src/test/java/seedu/letsgethired/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/letsgethired/logic/parser/ParserUtilTest.java
@@ -14,7 +14,7 @@ import seedu.letsgethired.model.application.Role;
 import seedu.letsgethired.model.application.Status;
 
 public class ParserUtilTest {
-    private static final String INVALID_COMPANY = "J@ne Street";
+    private static final String INVALID_COMPANY = "Jane/Street";
     private static final String INVALID_ROLE = " ";
     private static final String INVALID_STATUS = " ";
     private static final String INVALID_CYCLE = "Summer!2024";

--- a/src/test/java/seedu/letsgethired/model/application/CompanyTest.java
+++ b/src/test/java/seedu/letsgethired/model/application/CompanyTest.java
@@ -28,8 +28,7 @@ public class CompanyTest {
         // invalid company
         assertFalse(Company.isValidCompany("")); // empty string
         assertFalse(Company.isValidCompany(" ")); // spaces only
-        assertFalse(Company.isValidCompany("^")); // only non-alphanumeric characters
-        assertFalse(Company.isValidCompany("Apple*")); // contains non-alphanumeric characters
+        assertFalse(Company.isValidCompany("Apple/")); // contains '/' characters
 
         // valid company
         assertTrue(Company.isValidCompany("big company")); // alphabets only

--- a/src/test/java/seedu/letsgethired/model/application/InternApplicationTest.java
+++ b/src/test/java/seedu/letsgethired/model/application/InternApplicationTest.java
@@ -58,7 +58,7 @@ public class InternApplicationTest {
         // name differs in case, all other attributes same -> returns false
         InternApplication editedOtherInternApplication = new InternApplicationBuilder(B)
                 .withCompany(VALID_COMPANY_BYTEDANCE.toLowerCase()).build();
-        assertFalse(B.isSameApplication(editedOtherInternApplication));
+        assertTrue(B.isSameApplication(editedOtherInternApplication));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_COMPANY_BYTEDANCE + " ";

--- a/src/test/java/seedu/letsgethired/storage/JsonAdaptedInternApplicationTest.java
+++ b/src/test/java/seedu/letsgethired/storage/JsonAdaptedInternApplicationTest.java
@@ -20,7 +20,7 @@ import seedu.letsgethired.model.application.Role;
 import seedu.letsgethired.model.application.Status;
 
 public class JsonAdaptedInternApplicationTest {
-    private static final String INVALID_NAME = "J@ne";
+    private static final String INVALID_COMPANY = "Jane/Street";
     private static final String INVALID_ROLE = " ";
     private static final String INVALID_STATUS = " ";
     private static final String INVALID_CYCLE = "example.com";
@@ -48,7 +48,7 @@ public class JsonAdaptedInternApplicationTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedInternApplication application =
                 new JsonAdaptedInternApplication(
-                        INVALID_NAME, VALID_ROLE, VALID_CYCLE, VALID_NOTE, VALID_STATUS, VALID_DEADLINE);
+                        INVALID_COMPANY, VALID_ROLE, VALID_CYCLE, VALID_NOTE, VALID_STATUS, VALID_DEADLINE);
         String expectedMessage = Company.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, application::toModelType);
     }


### PR DESCRIPTION
Fixes #168 

All commands that have prefix inputs, check for multiple prefixes of same type now

Fixes #120 

Checking for duplicate internship applications is now case-insensitive for company, role and cycle

Fixes #126 and fixes #127

Company name now accepts all characters except the forward slash '/', and should not be blank

Fixes #121 

Commands are now case-insensitive

Prefixes would be better-off being case-sensitive, due to the nature of the ArgumentTokenizer (see ArgumentTokenizerTest to understand)